### PR TITLE
Refactored mpirun to not exec a second executable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "prrte"]
 	path = 3rd-party/prrte
-	url = ../../open-mpi/prrte
-	branch = master
+	url = ../../uofl-capstone-open-mpi/prrte
+	branch = capstone-devel
 [submodule "openpmix"]
 	path = 3rd-party/openpmix
 	url = ../../openpmix/openpmix.git

--- a/ompi/dpm/dpm.c
+++ b/ompi/dpm/dpm.c
@@ -1991,7 +1991,10 @@ static char *find_prte(void)
 #if OMPI_USING_INTERNAL_PRRTE
     /* 2) If using internal PRRTE, use our bindir.  Note that this
      * will obey OPAL_PREFIX and OPAL_DESTDIR */
-    opal_asprintf(&filename, "%s%sprte", opal_install_dirs.bindir, OPAL_PATH_SEP);
+/*
+ * TODO: HPP replace hard-wired prrte prefix with something configurable
+ */
+    opal_asprintf(&filename, "%s%sompi-prte", opal_install_dirs.bindir, OPAL_PATH_SEP);
     return filename;
 #else
 

--- a/ompi/tools/mpirun/Makefile.am
+++ b/ompi/tools/mpirun/Makefile.am
@@ -20,8 +20,12 @@ dist_ompidata_DATA = help-mpirun.txt
 mpirun_SOURCES = \
     main.c
 
+#
+# TODO: HPP replace hard-wired prrte prefix with something configurable
+#
 mpirun_LDADD = \
-	$(top_builddir)/opal/libopen-pal_core.la
+	$(top_builddir)/opal/libopen-pal_core.la \
+	$(top_builddir)/3rd-party/prrte/src/libompi-prrte.la
 
 mpirun_CPPFLAGS = \
     -DMCA_oshmem_FRAMEWORKS="\"$(MCA_oshmem_FRAMEWORKS)\"" \

--- a/ompi/tools/mpirun/help-mpirun.txt
+++ b/ompi/tools/mpirun/help-mpirun.txt
@@ -10,14 +10,8 @@
 # This is the US/English help file for Open MPI wrapper compiler error
 # messages.
 #
-[no-prterun-found]
-Open MPI's mpirun command was unable to find an underlying prterun
-command to execute.  Consider setting the OMPI_PRTERUN environment
-variable to help mpirun find the correct underlying prterun.
-[prterun-exec-failed]
-Open MPI's mpirun command could not execute the underlying prterun
-command.  The prterun command we tried to execute and the error
-message from exec() are below:
+[prte-launch-failed]
+Open MPI's mpirun command was unable to launch the user's application. 
+This may indicate an issue with the environment or incorrect configuration.
 
-  Command: %s
-  Error Message: %s
+Error Message: %s


### PR DESCRIPTION
Modified mpirun to no longer fork/exec prterun, but to instead instead call the function directly